### PR TITLE
Created warnings field in user schema. Updated unit tests to fix.

### DIFF
--- a/backend/app/data/users.json
+++ b/backend/app/data/users.json
@@ -5,7 +5,8 @@
     "hashed_password": "$2b$12$nCqzSBYg3ojbbx8WZXENmeSZVdFmrisWpWwj/nRSGBjfjTiachis.",
     "role": "admin",
     "created_at": "2025-10-20T23:09:02.346841",
-    "active": true
+    "active": true,
+    "warnings": 0
   },
   {
     "id": "77d60efe-0870-4323-b164-3d76474f251f",
@@ -13,6 +14,7 @@
     "hashed_password": "$2b$12$B6mJk/6rXrgrTFnq9YseZu6AIvuEZr1O2lKI6kIa2BJyjyHWz6Kya",
     "role": "user",
     "created_at": "2025-10-23T17:10:27.600472",
-    "active": true
+    "active": true,
+    "warnings": 0
   }
 ]

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -14,6 +14,7 @@ class User(BaseModel):
     role: Literal["user", "admin"]
     created_at: datetime
     active: bool = True
+    warnings: int = 0
     
 class UserCreate(BaseModel):
     """Schema for user registration"""

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,5 +1,20 @@
 from dotenv import load_dotenv
 import os
+import pytest
+import datetime
 
 def pytest_configure():
     load_dotenv()
+
+@pytest.fixture
+def user_data():
+    payload = {
+        "id": "1234",
+        "username": "testmovielover",
+        "hashed_password": "$2y$10$b1d2DgDhd1bdRbiwSqfZs.MhtyNCMHaYbQp3.6D3ngYLQ9ySTM/HO",
+        "role": "user",
+        "created_at": datetime.datetime.now(),
+        "active": True,
+        "warnings": 0
+    }
+    return payload

--- a/backend/tests/test_battle_service.py
+++ b/backend/tests/test_battle_service.py
@@ -19,6 +19,7 @@ def user():
         hashed_password="hashed",
         role="user",
         created_at=datetime.now(),
+        warnings=0
     )
 
 @pytest.fixture
@@ -27,7 +28,7 @@ def reviews():
     return [
         Review(
             id=i,
-            movieId=1,
+            movieId="a",
             authorId=100 + i,
             rating=4.5,
             reviewTitle=f"Title {i}",
@@ -51,15 +52,16 @@ def test_create_battle_excludes_own_reviews(mocker):
         role="user",
         created_at=datetime(2025, 10, 23, 15, 13, 59, 543758),
         active=True,
+        warnings=0
     )
 
     # --- Setup reviews ---
     reviews = [
-    Review(id=1, movieId=1, authorId=101, rating=4.5, reviewTitle="Title 1", reviewBody="Body 1", flagged=False, votes=0, date=date(2025, 10, 23)),
-    Review(id=2, movieId=1, authorId=101, rating=4.0, reviewTitle="Title 2", reviewBody="Body 2", flagged=False, votes=0, date=date(2025, 10, 23)),
-    Review(id=3, movieId=1, authorId=102, rating=3.5, reviewTitle="Title 3", reviewBody="Body 3", flagged=False, votes=0, date=date(2025, 10, 23)),
-    Review(id=4, movieId=1, authorId=103, rating=5.0, reviewTitle="Title 4", reviewBody="Body 4", flagged=False, votes=0, date=date(2025, 10, 23)),
-    Review(id=5, movieId=1, authorId=104, rating=2.5, reviewTitle="Title 5", reviewBody="Body 5", flagged=False, votes=0, date=date(2025, 10, 23)),
+    Review(id=1, movieId="a", authorId=101, rating=4.5, reviewTitle="Title 1", reviewBody="Body 1", flagged=False, votes=0, date=date(2025, 10, 23)),
+    Review(id=2, movieId="a", authorId=101, rating=4.0, reviewTitle="Title 2", reviewBody="Body 2", flagged=False, votes=0, date=date(2025, 10, 23)),
+    Review(id=3, movieId="a", authorId=102, rating=3.5, reviewTitle="Title 3", reviewBody="Body 3", flagged=False, votes=0, date=date(2025, 10, 23)),
+    Review(id=4, movieId="a", authorId=103, rating=5.0, reviewTitle="Title 4", reviewBody="Body 4", flagged=False, votes=0, date=date(2025, 10, 23)),
+    Review(id=5, movieId="a", authorId=104, rating=2.5, reviewTitle="Title 5", reviewBody="Body 5", flagged=False, votes=0, date=date(2025, 10, 23)),
     ]
 
     # --- Mock previous battles for this user ---

--- a/backend/tests/test_user_schema.py
+++ b/backend/tests/test_user_schema.py
@@ -1,19 +1,6 @@
 import pytest
 from pydantic import ValidationError
 from app.schemas.user import User, UserCreate, UserUpdate
-import datetime
-
-@pytest.fixture
-def user_data():
-    payload = {
-        "id": "1234",
-        "username": "testmovielover",
-        "hashed_password": "$2y$10$b1d2DgDhd1bdRbiwSqfZs.MhtyNCMHaYbQp3.6D3ngYLQ9ySTM/HO",
-        "role": "user",
-        "created_at": datetime.datetime.now(),
-        "active": True
-    }
-    return payload
 
 def test_missing_required_fields():
     with pytest.raises(ValidationError):
@@ -23,6 +10,10 @@ def test_valid_user(user_data):
     user = User(**user_data)
     assert user.username == user_data["username"]
     assert user.active is True
+
+def test_valid_user_default_warnings(user_data):
+    user = User(**user_data)
+    assert user.warnings == user_data["warnings"]
 
 def test_username_too_short(user_data):
     with pytest.raises(ValidationError):


### PR DESCRIPTION
This short PR introduces the warnings field in the User data model and updates the users.json to reflect users with 0 warnings.

The warnings fields were added to unit tests and the user_data fixture moved to conftest.py for reuse.

A small bugfix of changing movie fields to strings in test_battle_service.py allows tests to pass, as this was not updated after movie Ids were changed to strings.