### PR TITLE
Add fetch-depth option to checkout step

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -22,7 +22,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-
+        with:
+          ref: ${{ github.head_ref }}
+          fetch-depth: 0
       - name: Set up Python 3.13
         uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
Branch tests should now run on the committed branch, not main