### PR TITLE
Added visible property to Review model

### DIFF
--- a/backend/app/schemas/review.py
+++ b/backend/app/schemas/review.py
@@ -18,6 +18,7 @@ class Review(BaseModel):
     flagged: bool = False
     votes: int = 0
     date: date
+    visible: bool = True
 
     if _P2:
         @_field_validator("movieId", mode="before")


### PR DESCRIPTION
This PR closes #129 

Adds a "visible" field to Review which will determine if users can see the review or not.
No updates to reviews.json are necessary as the default for Review objects if not specified is visible=True.