### PR TITLE
Refactor/JWT auth_middleware.py and validate_access.py

### DIFF
--- a/backend/app/middleware/auth_middleware.py
+++ b/backend/app/middleware/auth_middleware.py
@@ -1,15 +1,19 @@
-from fastapi import Request, HTTPException, Depends
+from fastapi import Request, HTTPException
+import jwt
+
 from app.services.validate_access import validate_user_access
+
 
 async def jwt_auth_dependency(request: Request):
     auth_header = request.headers.get("Authorization")
     if not auth_header or not auth_header.startswith("Bearer "):
-        raise HTTPException(status_code = 401, detail = "Access Token Missing")
-    
+        raise HTTPException(status_code=401, detail="Access Token Missing")
+
     access_token = auth_header.split(" ")[1]
 
     try:
         payload = validate_user_access(access_token)
         return payload
-    except Exception as ex:
-        raise HTTPException(status_code=401, detail=str(ex))
+    except (jwt.ExpiredSignatureError, jwt.InvalidTokenError) as ex:
+        # Known JWT validation failure -> 401
+        raise HTTPException(status_code=401, detail=str(ex)) from ex

--- a/backend/app/services/validate_access.py
+++ b/backend/app/services/validate_access.py
@@ -1,16 +1,17 @@
-import jwt
 import os
+from typing import Dict, Any
+
+import jwt
 
 JWT_SECRET = os.getenv("JWT_SECRET")
 if not JWT_SECRET:
     raise RuntimeError("JWT SECRET could not be loaded")
 
-def validate_user_access(access_token):
-    try:
-        jwt_decoded = jwt.decode(access_token, JWT_SECRET, algorithms=["HS256"])
-        return jwt_decoded
-    except jwt.ExpiredSignatureError:
-        raise jwt.ExpiredSignatureError
-    except jwt.InvalidTokenError:
-        raise jwt.InvalidTokenError
+
+def validate_user_access(access_token: str) -> Dict[str, Any]:
+    """
+    Decode and validate a JWT access token.
+    Returns the decoded payload on success or lets jwt decode errors propagate.
+    """
+    return jwt.decode(access_token, JWT_SECRET, algorithms=["HS256"])
 


### PR DESCRIPTION
- /services/validate_access.py
    - Added type hints and docstring:
        - def validate_user_access(access_token: str) -> Dict[str, Any]:
        - Docstring explains it decodes and validates a JWT and lets decode errors propagate.
    - Removed the redundant try/except that re-raised the same exceptions.
    - Now simply:
        - return jwt.decode(access_token, JWT_SECRET, algorithms=["HS256"])
- /middleware/auth_middleware.py
    - Removed the broad except Exception as ex.
    - Imported jwt and now only catches JWT-related errors:
        - except (jwt.ExpiredSignatureError, jwt.InvalidTokenError) as ex:
        - These are translated to HTTPException(status_code=401, detail=str(ex)) with from ex to preserve tracebacks.
    - Other unexpected errors will now propagate rather than being turned into 401s.