### PR TITLE
Refactor/user_login_service.py

### DIFF
--- a/backend/app/services/user_login_service.py
+++ b/backend/app/services/user_login_service.py
@@ -1,37 +1,50 @@
-from app.schemas.user_login import UserLogin
-from app.repositories.user_repo import load_all
-import bcrypt
-from fastapi import HTTPException
-import jwt
 from datetime import datetime, timedelta, timezone
 import os
+
+import bcrypt
+import jwt
+from fastapi import HTTPException
+
+from app.repositories.user_repo import load_all
+from app.schemas.user_login import UserLogin
 
 JWT_SECRET = os.getenv("JWT_SECRET")
 if not JWT_SECRET:
     raise RuntimeError("JWT SECRET could not be loaded")
 
-def user_login(payload: UserLogin) -> str:
-    users = load_all()
-    found_user = next((user for user in users if user.get("username") == payload.username), None)
-    if found_user == None:
-        raise HTTPException(401, detail="Invalid credentials")
-    
-    password_valid = bcrypt.checkpw(payload.password.encode("utf-8"), found_user.get("hashed_password").encode("utf-8"))
-    if not password_valid:
-        raise HTTPException(401, detail="Invalid credentials")
-    
-    if found_user.get("active") == False:
-        raise BannedUserException(403, detail="Account banned")
-    
+INVALID_CREDENTIALS = HTTPException(401, detail="Invalid credentials")
+
+
+def _build_access_token(found_user: dict) -> str:
     current_datetime = datetime.now(timezone.utc)
     expiration_time = current_datetime + timedelta(hours=1)
-    user_payload = {"user_id": found_user.get("id"),
-                    "username": found_user.get("username"),
-                    "exp": expiration_time,
-                    "role": found_user.get("role")}
-    encoded_jwt = jwt.encode(user_payload, JWT_SECRET, algorithm="HS256")
-    
-    return encoded_jwt
-    
+    user_payload = {
+        "user_id": found_user.get("id"),
+        "username": found_user.get("username"),
+        "exp": expiration_time,
+        "role": found_user.get("role"),
+    }
+    return jwt.encode(user_payload, JWT_SECRET, algorithm="HS256")
+
+
+def user_login(payload: UserLogin) -> str:
+    users = load_all()
+    found_user = next((user for user in users if user.get("username") == getattr(payload, "username", None)), None)
+    if found_user is None:
+        raise INVALID_CREDENTIALS
+
+    password_valid = bcrypt.checkpw(
+        getattr(payload, "password", "").encode("utf-8"),
+        found_user.get("hashed_password").encode("utf-8"),
+    )
+    if not password_valid:
+        raise INVALID_CREDENTIALS
+
+    if found_user.get("active") is False:
+        raise BannedUserException(403, detail="Account banned")
+
+    return _build_access_token(found_user)
+
+
 class BannedUserException(HTTPException):
     pass


### PR DESCRIPTION
- Introduced a shared constant:
    - INVALID_CREDENTIALS = HTTPException(401, detail="Invalid credentials")
    - Both invalid-username and invalid-password paths now raise this single constant.
- Switched to identity checks:
    - if found_user is None: instead of == None.
    - if found_user.get("active") is False: instead of == False.
- Extracted token-building logic:
    - Added _build_access_token(found_user: dict) -> str that:
        - Computes exp (now + 1 hour),
        - Builds the payload with user_id, username, role, and exp,
        - Returns jwt.encode(...).
    - user_login now ends with return _build_access_token(found_user).