### PR TITLE
Add sprint 4 meeting notes and action items

### DIFF
--- a/scrum-documents/sprint-4-meetings.md
+++ b/scrum-documents/sprint-4-meetings.md
@@ -1,0 +1,26 @@
+# Sprint 4: Core Features & Milestone 4
+**Sprint Duration:** October 18 - December 4, 2025  
+**Sprint Goal:** Implement core frontend features, and complete Milestone 4 (integrate 4 additional features, 1 external API)
+
+---
+
+## Meeting Date: 2025-11-26
+**Type of Meeting:** In-person Scrum
+**Meeting Length:** 11:00-11:45
+**Attendees:** Everyone
+
+### Action Items
+- Assign coding tasks as we lead up to M4 submission. 
+- Review the code produced over the past week.
+- Team learning session
+
+### Meeting Notes
+We outlined the requirements for M4, and what we needed to complete in order to be ready for a possible demo scheduled tuesday. Brad outlined his register page, and gave some helpful tips for implementation.
+
+### Responsibilities
+- Brad - Login, register, session handling, admin dashboard frontend. View all users in admin dashboard for moderation.
+- Duncan - Frontend `/movies`, return list of all movies (ids, names). Should be able to click on one, and go to the individual movie summary page. Movies leaderboard (following reviews leaderboard).
+- Kelvin - Movie summary frontend, which shows all the relevant reviews for that movie. Links to Duncan's `/movies`. 
+- Will - Review battles frontend, integrate TMDb API. Frontend for reviews CRUD.
+
+---


### PR DESCRIPTION
Created scrum-documents/sprint-4-meetings.md to document the sprint 4 meeting, including action items, responsibilities, and notes for milestone 4 preparation.